### PR TITLE
Correct link to LA parking citations data

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ or
 python parking_parser.py --help
 ```
 ## Where to get the Data
-* City of LA Parking Tickets: https://data.lacity.org/A-Well-Run-City/Parking-Citations/t4h6-r362
+* City of LA Parking Tickets: https://data.lacity.org/A-Well-Run-City/Parking-Citations/wjz9-h9np
 * City of LA Meter Zones: http://geohub.lacity.org/datasets/71c26db1ad614faab1047cc8c3686ece_28
 * LA Times Neighborhood Polygons: http://boundaries.latimes.com/sets/
 


### PR DESCRIPTION
👋 Hey there - looks like the city changed the parking ticket URL, so I updated the link in the readme.

BTW, I'm part of a small python learning group that's organizing a project around processing and visualizing LA parking ticket data; we're coordinating in the #data-enthusiasts channel on [Hack for LA's Slack](https://hackforla.slack.com/messages/CGRATJCCF/details/) (you're welcome to drop by ^_^). Someone there pointed out your [LACounts story](https://www.lacounts.org/story/silver-lake-parking-tickets) on the subject, which led me to this repo. Thanks for open sourcing your work :+1: